### PR TITLE
Adding entryoints in `pyproject.toml` for pipx install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,7 @@ build = [
 twine = [
     "twine"
 ]
+
+[project.scripts]
+geowordlists = "geowordlists.__main__:main"
+GeoWordlists = "geowordlists.__main__:main"


### PR DESCRIPTION
The command `pipx install git+https://github.com/p0dalirius/GeoWordlists` was working with pipx v1.2.0 but stopped working with 1.2.1, raising the following error.

```
No apps associated with package geowordlists or its dependencies. If you are attempting to install a library, pipx should not be
used. Consider using pip or a similar tool instead.
```

While the package specifies its apps in `setup.py`, it doesn't do that in `pyproject.toml`, hence the error.
The PR fixes that by adding the entrypoints to the TOML config.